### PR TITLE
New way of getting of Sinatra settings - authorization_realm

### DIFF
--- a/lib/sinatra/authorization.rb
+++ b/lib/sinatra/authorization.rb
@@ -22,7 +22,7 @@ module Sinatra
     # From you app, call set :authorization_realm, "my app" to set this
     # or define a #authorization_realm method in your helpers block.
     def authorization_realm
-      Sinatra::Default.authorization_realm
+      settings.authorization_realm
     end
 
     # Call in any event that requires authentication

--- a/test/authorization_test.rb
+++ b/test/authorization_test.rb
@@ -1,7 +1,7 @@
 require "test/unit"
 require "rack/test"
-require "context"
-require "pending"
+#require "context"
+#require "pending"
 
 require File.dirname(__FILE__) + "/../lib/sinatra/authorization"
 

--- a/test/authorization_test.rb
+++ b/test/authorization_test.rb
@@ -1,7 +1,7 @@
 require "test/unit"
 require "rack/test"
-#require "context"
-#require "pending"
+require "context"
+require "pending"
 
 require File.dirname(__FILE__) + "/../lib/sinatra/authorization"
 


### PR DESCRIPTION
I've changed a way of getting a particular setting value from Sinatra from:

```
Sinatra::Default.authorization_realm
```

to:

```
settings.authorization_realm
```
